### PR TITLE
oauthCallback defined to "oob"

### DIFF
--- a/sample/Secret.hs
+++ b/sample/Secret.hs
@@ -11,4 +11,5 @@ tokens :: OAuth
 tokens = twitterOAuth
   { oauthConsumerKey = error "You MUST specify oauthConsumerKey parameter."
   , oauthConsumerSecret = error "You MUST specify oauthConsumerSecret parameter."
+  , oauthCallback = Just "oob"
   }


### PR DESCRIPTION
The program will ask for PIN only when ouathCallback is set to "oob".

Reference: https://dev.twitter.com/docs/auth/pin-based-authorization

The example programs worked only after adding this field.
