### PR TITLE
Add shield that shows status of Hackage deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # twitter-conduit: An Conduit based Twitter API library for Haskell #
 
-[![Build Status](https://travis-ci.org/himura/twitter-conduit.png?branch=master)](https://travis-ci.org/himura/twitter-conduit)
+[![Travis](https://img.shields.io/travis/himura/twitter-conduit.svg)](https://travis-ci.org/himura/twitter-conduit)
+[![Hackage-Deps](https://img.shields.io/hackage-deps/v/twitter-conduit.svg)](http://packdeps.haskellers.com/feed?needle=twitter-conduit)
 
 ## About ##
 


### PR DESCRIPTION
This new shield shows whether the version bounds of Hackage dependencies are still up-to-date. Preview:

[![Hackage-Deps](https://img.shields.io/hackage-deps/v/twitter-conduit.svg)](http://packdeps.haskellers.com/feed?needle=twitter-conduit)

Looks like there is a new version of lens!