### PR TITLE
Relaxed lens version restrictions.

### DIFF
--- a/twitter-conduit.cabal
+++ b/twitter-conduit.cabal
@@ -75,10 +75,10 @@ library
   if flag(lens-aeson)
     build-depends:
         lens-aeson >= 1
-      , lens >= 4.4 && < 4.8
+      , lens >= 4.4
   else
     build-depends:
-        lens >= 4.0 && < 4.4
+        lens >= 4.0
 
   exposed-modules:
     Web.Twitter.Conduit


### PR DESCRIPTION
Relaxing the version restrictions on the lens library allows twitter-conduit to be compiled with GHC 7.10.1.