### PR TITLE
Implement account/update_profile

### DIFF
--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -141,7 +141,7 @@ module Web.Twitter.Conduit.Api
        ) where
 
 import Web.Twitter.Types
-import Web.Twitter.Conduit.Parameters
+import Web.Twitter.Conduit.Parameters hiding (description, name, url)
 import Web.Twitter.Conduit.Parameters.TH
 import Web.Twitter.Conduit.Base
 import Web.Twitter.Conduit.Request

--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -509,7 +509,17 @@ deriveHasParamInstances ''AccountVerifyCredentials
     ]
 
 data AccountUpdateProfile
-
+-- | Returns user object with updated fields.
+-- Note that while no specific parameter is required, you need to provide at least one parameter before executing the query.
+--
+-- You can perform request by using 'call':
+--
+-- @
+-- res <- 'call' twInfo mgr '$' 'accountUpdateProfile' & 'Web.Twitter.Conduit.Parameters.url' ?~ \"http://www.example.com\"
+-- @
+--
+-- >>> accountUpdateProfile & url ?~ "http://www.example.com"
+-- APIRequestPost "https://api.twitter.com/1.1/account/update_profile.json" [("url","http://www.example.com")]
 accountUpdateProfile :: APIRequest AccountUpdateProfile User
 accountUpdateProfile = APIRequestPost (endpoint ++ "account/update_profile.json") []
 deriveHasParamInstances ''AccountUpdateProfile

--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -52,7 +52,7 @@ module Web.Twitter.Conduit.Api
        , accountVerifyCredentials
        -- , accountSettingsUpdate
        -- , accountUpdateDeliveryDevice
-       -- , accountUpdateProfile
+       , accountUpdateProfile
        -- , accountUpdateProfileBackgroundImage
        -- , accountUpdateProfileColors
        -- , accoutUpdateProfileImage
@@ -506,6 +506,20 @@ accountVerifyCredentials = APIRequestGet (endpoint ++ "account/verify_credential
 deriveHasParamInstances ''AccountVerifyCredentials
     [ "include_entities"
     , "skip_status"
+    ]
+
+data AccountUpdateProfile
+
+accountUpdateProfile :: APIRequest AccountUpdateProfile User
+accountUpdateProfile = APIRequestPost (endpoint ++ "account/update_profile.json") []
+deriveHasParamInstances ''AccountUpdateProfile
+    [ "include_entities"
+    , "skip_status"
+    , "name"
+    , "url"
+    , "location"
+    , "description"
+    , "profile_link_color"
     ]
 
 data UsersLookup

--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -142,7 +142,7 @@ module Web.Twitter.Conduit.Api
        ) where
 
 import Web.Twitter.Types
-import Web.Twitter.Conduit.Parameters hiding (description, name, url)
+import Web.Twitter.Conduit.Parameters hiding (description, name)
 import Web.Twitter.Conduit.Parameters.TH
 import Web.Twitter.Conduit.Base
 import Web.Twitter.Conduit.Request

--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -52,6 +52,7 @@ module Web.Twitter.Conduit.Api
        , accountVerifyCredentials
        -- , accountSettingsUpdate
        -- , accountUpdateDeliveryDevice
+       , AccountUpdateProfile
        , accountUpdateProfile
        -- , accountUpdateProfileBackgroundImage
        -- , accountUpdateProfileColors

--- a/Web/Twitter/Conduit/Base.hs
+++ b/Web/Twitter/Conduit/Base.hs
@@ -22,7 +22,7 @@ module Web.Twitter.Conduit.Base
        ) where
 
 import Web.Twitter.Conduit.Cursor
-import Web.Twitter.Conduit.Parameters
+import Web.Twitter.Conduit.Parameters hiding (url)
 import Web.Twitter.Conduit.Request
 import Web.Twitter.Conduit.Response
 import Web.Twitter.Conduit.Types

--- a/Web/Twitter/Conduit/Parameters.hs
+++ b/Web/Twitter/Conduit/Parameters.hs
@@ -34,6 +34,11 @@ module Web.Twitter.Conduit.Parameters
        , HasFollowParam (..)
        , HasMapParam (..)
        , HasMediaIdsParam (..)
+       , HasDescriptionParam (..)
+       , HasNameParam (..)
+       , HasProfileLinkColorParam (..)
+       , HasLocationParam (..)
+       , HasUrlParam (..)
 
        , UserParam(..)
        , UserListParam(..)
@@ -85,6 +90,11 @@ defineHasParamClassBool "skip_status"
 defineHasParamClassBool "follow"
 defineHasParamClassBool "map"
 defineHasParamClassIntegerArray "media_ids"
+defineHasParamClassString "description"
+defineHasParamClassString "name"
+defineHasParamClassString "profile_link_color"
+defineHasParamClassString "location"
+defineHasParamClassURI "url"
 
 -- | converts 'UserParam' to 'HT.SimpleQuery'.
 --

--- a/Web/Twitter/Conduit/Parameters/TH.hs
+++ b/Web/Twitter/Conduit/Parameters/TH.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString as S
 import Data.Char
 import Data.Text (Text)
 import Data.Time.Calendar (Day)
+import Web.Twitter.Types
 
 snakeToLowerCamel :: String -> String
 snakeToLowerCamel [] = []
@@ -91,6 +92,10 @@ defineHasParamClassBool =
 defineHasParamClassString :: String -> Q [Dec]
 defineHasParamClassString =
     defineHasParamClass 'PVString 'unPVString [t|Text|]
+
+defineHasParamClassURI :: String -> Q [Dec]
+defineHasParamClassURI =
+    defineHasParamClass 'PVString 'unPVString [t|URIString|]
 
 defineHasParamClassIntegerArray :: String -> Q [Dec]
 defineHasParamClassIntegerArray =

--- a/sample/oauth_callback.hs
+++ b/sample/oauth_callback.hs
@@ -9,7 +9,7 @@ module Main where
 
 import Web.Scotty
 import qualified Network.HTTP.Types as HT
-import Web.Twitter.Conduit hiding (lookup)
+import Web.Twitter.Conduit hiding (lookup,url)
 import qualified Web.Authenticate.OAuth as OA
 import qualified Data.Text.Lazy as LT
 import qualified Data.ByteString as S

--- a/sample/oauth_pin.hs
+++ b/sample/oauth_pin.hs
@@ -8,7 +8,7 @@
 
 module Main where
 
-import Web.Twitter.Conduit hiding (lookup)
+import Web.Twitter.Conduit hiding (lookup,url)
 import Web.Authenticate.OAuth as OA
 import qualified Data.ByteString.Char8 as S8
 import Data.Maybe

--- a/sample/post.hs
+++ b/sample/post.hs
@@ -4,6 +4,7 @@ module Main where
 import Web.Twitter.Conduit hiding (map)
 import Common
 
+import Control.Applicative
 import Data.Monoid
 import qualified Data.Text as T
 import qualified Data.Text.IO as T

--- a/sample/post.hs
+++ b/sample/post.hs
@@ -4,7 +4,6 @@ module Main where
 import Web.Twitter.Conduit hiding (map)
 import Common
 
-import Control.Applicative
 import Data.Monoid
 import qualified Data.Text as T
 import qualified Data.Text.IO as T

--- a/sample/simple.hs
+++ b/sample/simple.hs
@@ -3,7 +3,7 @@
 
 module Main where
 
-import Web.Twitter.Conduit
+import Web.Twitter.Conduit hiding (url)
 import Web.Twitter.Types.Lens
 
 import Control.Lens

--- a/sample/userstream.hs
+++ b/sample/userstream.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 
-import Web.Twitter.Conduit
+import Web.Twitter.Conduit hiding (url)
 import Web.Twitter.Types.Lens
 import Common
 
-import Control.Applicative
 import Control.Lens
 import Control.Monad
 import Control.Monad.IO.Class

--- a/sample/userstream.hs
+++ b/sample/userstream.hs
@@ -5,6 +5,7 @@ import Web.Twitter.Conduit hiding (url)
 import Web.Twitter.Types.Lens
 import Common
 
+import Control.Applicative
 import Control.Lens
 import Control.Monad
 import Control.Monad.IO.Class


### PR DESCRIPTION
Implement account/update_profile.

Note that this also introduced few commonly used identifier names like `url`, `name` and `description` causing variable shadowing warnings on those that exports `Web.Twitter.Conduit.Parameters`.