### PR TITLE
Replace SearchStatus with Status type

### DIFF
--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -170,7 +170,7 @@ data SearchTweets
 -- >>> searchTweets "search text" & lang ?~ "ja" & count ?~ 100
 -- APIRequestGet "https://api.twitter.com/1.1/search/tweets.json" [("count","100"),("lang","ja"),("q","search text")]
 searchTweets :: T.Text -- ^ search string
-             -> APIRequest SearchTweets (SearchResult [SearchStatus])
+             -> APIRequest SearchTweets (SearchResult [Status])
 searchTweets q = APIRequestGet (endpoint ++ "search/tweets.json") [("q", PVString q)]
 deriveHasParamInstances ''SearchTweets
     [ "lang"
@@ -186,7 +186,7 @@ deriveHasParamInstances ''SearchTweets
 
 -- | Alias of 'searchTweets', for backward compatibility
 search :: T.Text -- ^ search string
-       -> APIRequest SearchTweets (SearchResult [SearchStatus])
+       -> APIRequest SearchTweets (SearchResult [Status])
 search = searchTweets
 
 data DirectMessages


### PR DESCRIPTION
According to https://dev.twitter.com/rest/reference/get/search/tweets, the Search API now returns more detailed Tweet objects:

> In API v1.1, the response format of the Search API has been improved to return Tweet objects more similar to the objects you’ll find across the REST API and platform. However, perspectival attributes (fields that pertain to the perspective of the authenticating user) are not currently supported on this endpoint.

The website is not very detailed about this, but I tested the search API with this change and all the fields of `Status` were there, and everything worked fine. 