### PR TITLE
Added "full_text" parameter to direct message calls.

### DIFF
--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -210,6 +210,7 @@ deriveHasParamInstances ''DirectMessages
     , "count"
     , "include_entities"
     , "skip_status"
+    , "full_text"
     ]
 
 data DirectMessagesSent
@@ -234,6 +235,7 @@ deriveHasParamInstances ''DirectMessagesSent
     , "include_entities"
     , "page"
     , "skip_status"
+    , "full_text"
     ]
 
 data DirectMessagesShow
@@ -249,6 +251,9 @@ data DirectMessagesShow
 -- APIRequestGet "https://api.twitter.com/1.1/direct_messages/show.json" [("id","1234567890")]
 directMessagesShow :: StatusId -> APIRequest DirectMessagesShow DirectMessage
 directMessagesShow sId = APIRequestGet (endpoint ++ "direct_messages/show.json") [("id", PVInteger sId)]
+deriveHasParamInstances ''DirectMessagesShow
+    [ "full_text"
+    ]
 
 data DirectMessagesDestroy
 -- | Returns post data which destroys the direct message specified in the required ID parameter.

--- a/Web/Twitter/Conduit/Parameters.hs
+++ b/Web/Twitter/Conduit/Parameters.hs
@@ -34,6 +34,7 @@ module Web.Twitter.Conduit.Parameters
        , HasFollowParam (..)
        , HasMapParam (..)
        , HasMediaIdsParam (..)
+       , HasFullTextParam (..)
 
        , UserParam(..)
        , UserListParam(..)
@@ -85,6 +86,7 @@ defineHasParamClassBool "skip_status"
 defineHasParamClassBool "follow"
 defineHasParamClassBool "map"
 defineHasParamClassIntegerArray "media_ids"
+defineHasParamClassBool "full_text"
 
 -- | converts 'UserParam' to 'HT.SimpleQuery'.
 --


### PR DESCRIPTION
As described at
https://twittercommunity.com/t/removing-the-140-character-limit-from-direct-messages/41348