### PR TITLE
Upgrade http-conduit and http-client dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.2.2.1
+
+* Upgrade http-conduit and http-client dependencies to:
+  http-conduit >= 2.1.8 && http-client >= 0.4.30
+
 ## 0.2.2
 
 * Added `include_email` parameter to `AccountVerifyCredentials` [#49](https://github.com/himura/twitter-conduit/pull/49)

--- a/Web/Twitter/Conduit/Base.hs
+++ b/Web/Twitter/Conduit/Base.hs
@@ -62,14 +62,12 @@ makeRequest' :: HT.Method -- ^ HTTP request method (GET or POST)
              -> HT.SimpleQuery -- ^ Query
              -> IO HTTP.Request
 makeRequest' m url query = do
-    req <- HTTP.parseUrl url
+    req <- HTTP.parseRequest url
     let addParams =
             if m == "POST"
             then HTTP.urlEncodedBody query
             else \r -> r { HTTP.queryString = HT.renderSimpleQuery False query }
-    return $ addParams $ req { HTTP.method = m
-                             , HTTP.checkStatus = \_ _ _ -> Nothing
-                             }
+    return $ addParams $ req { HTTP.method = m }
 
 getResponse :: MonadResource m
             => TWInfo

--- a/twitter-conduit.cabal
+++ b/twitter-conduit.cabal
@@ -1,5 +1,5 @@
 name:              twitter-conduit
-version:           0.2.2
+version:           0.2.2.1
 license:           BSD3
 license-file:      LICENSE
 author:            HATTORI Hiroki, Hideyuki Tanaka, Takahiro HIMURA
@@ -64,8 +64,8 @@ library
     , conduit >= 1.1
     , conduit-extra >= 1.1
     , http-types
-    , http-conduit >= 2.0 && < 2.2
-    , http-client >= 0.3
+    , http-conduit >= 2.1.8
+    , http-client >= 0.4.30
     , aeson >= 0.7.0.5
     , attoparsec >= 0.10
     , data-default >= 0.3


### PR DESCRIPTION
New version bounds: http-conduit >= 2.1.8 && http-client >= 0.4.30