### PR TITLE
redo Setup.hs as it has been redone in all the ekmett projects

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,46 +1,23 @@
-#!/usr/bin/env runhaskell
-
--- This code is mostly borrowed from
--- https://github.com/ekmett/lens/blob/4b032a0047f9ecf687947541211487c9d6244f3e/Setup.lhs
-
-import Data.List (nub)
-import Data.Version (showVersion)
-import Distribution.Package (PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName)
-import Distribution.PackageDescription (PackageDescription(), TestSuite(..))
-import Distribution.Simple (defaultMainWithHooks, UserHooks(..), simpleUserHooks)
-import Distribution.Simple.Utils (rewriteFile, createDirectoryIfMissingVerbose)
-import Distribution.Simple.BuildPaths (autogenModulesDir)
-import Distribution.Simple.Setup (BuildFlags(buildVerbosity), fromFlag)
-import Distribution.Simple.LocalBuildInfo (withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps))
-import Distribution.Verbosity (Verbosity)
-import System.FilePath ((</>))
-
+{-# LANGUAGE CPP #-}
+module Main (main) where
+#ifndef MIN_VERSION_cabal_doctest
+#define MIN_VERSION_cabal_doctest(x,y,z) 0
+#endif
+#if MIN_VERSION_cabal_doctest(1,0,0)
+import Distribution.Extra.Doctest ( defaultMainWithDoctests )
 main :: IO ()
-main = defaultMainWithHooks hooks
+main = defaultMainWithDoctests "doctests"
+#else
+#ifdef MIN_VERSION_Cabal
+-- If the macro is defined, we have new cabal-install,
+-- but for some reason we don't have cabal-doctest in package-db
+--
+-- Probably we are running cabal sdist, when otherwise using new-build
+-- workflow
+import Warning ()
+#endif
+import Distribution.Simple
+main :: IO ()
+main = defaultMain
+#endif
 
-hooks :: UserHooks
-hooks =
-    simpleUserHooks
-    { buildHook = \pkg lbi hooks flags -> do
-           generateBuildModule (fromFlag (buildVerbosity flags)) pkg lbi
-           buildHook simpleUserHooks pkg lbi hooks flags
-    }
-
-generateBuildModule :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
-generateBuildModule verbosity pkg lbi = do
-  let dir = autogenModulesDir lbi
-  createDirectoryIfMissingVerbose verbosity True dir
-  withLibLBI pkg lbi $ \_ libcfg ->
-    withTestLBI pkg lbi $ \suite suitecfg ->
-      rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
-        [ "module Build_" ++ testName suite ++ " where"
-        , "deps :: [String]"
-        , "deps = " ++ show (formatdeps (testDeps libcfg suitecfg))
-        ]
-  where
-    formatdeps = map (formatone . snd)
-    formatone p = case packageName p of
-      PackageName n -> n ++ "-" ++ showVersion (packageVersion p)
-
-testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, PackageId)]
-testDeps xs ys = nub $ componentPackageDeps xs ++ componentPackageDeps ys

--- a/Warning.hs
+++ b/Warning.hs
@@ -1,0 +1,5 @@
+module Warning
+  {-# WARNING ["You are configuring this package without cabal-doctest installed.",
+               "The doctests test-suite will not work as a result.",
+               "To fix this, install cabal-doctest before configuring."] #-}
+  () where


### PR DESCRIPTION
I have no idea if this is right, but the Setup seems to have been copied from lens, and this is the change that was made in lens. (It also lets it build with ghc 8.2.1-rc2)