### PR TITLE
Adding 'with' parameter for Streaming API

### DIFF
--- a/Web/Twitter/Conduit/Parameters.hs
+++ b/Web/Twitter/Conduit/Parameters.hs
@@ -42,6 +42,7 @@ module Web.Twitter.Conduit.Parameters
        , HasLocationParam (..)
        , HasUrlParam (..)
        , HasFullTextParam (..)
+       , HasWithParam (..)
 
        , UserParam(..)
        , UserListParam(..)
@@ -101,6 +102,7 @@ defineHasParamClassString "profile_link_color"
 defineHasParamClassString "location"
 defineHasParamClassURI "url"
 defineHasParamClassBool "full_text"
+defineHasParamClassString "with"
 
 -- | converts 'UserParam' to 'HT.SimpleQuery'.
 --


### PR DESCRIPTION
The user streaming API can take a "with" parameter to allow filtering out followed tweets, and keep only tweets that involves the current user.