### PR TITLE
add support for http-conduit-2.3 and conduit-1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,12 @@ matrix:
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.1"
+    - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.3"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.3], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/Web/Twitter/Conduit/Base.hs
+++ b/Web/Twitter/Conduit/Base.hs
@@ -83,8 +83,8 @@ getResponse :: MonadResource m
             => TWInfo
             -> HTTP.Manager
             -> HTTP.Request
-#if MIN_VERSION_conduit(1,3,0)
-            -> m (Response (C.ConduitT () ByteString m ()))
+#if MIN_VERSION_http_conduit(2,3,0)
+            -> m (Response (C.ConduitM () ByteString m ()))
 #else
             -> m (Response (C.ResumableSource m ByteString))
 #endif
@@ -101,15 +101,15 @@ endpoint :: String
 endpoint = "https://api.twitter.com/1.1/"
 
 getValue ::
-#if MIN_VERSION_conduit(1,3,0)
-            Response (C.ConduitT () ByteString (ResourceT IO) ())
+#if MIN_VERSION_http_conduit(2,3,0)
+            Response (C.ConduitM () ByteString (ResourceT IO) ())
 #else
             Response (C.ResumableSource (ResourceT IO) ByteString)
 #endif
          -> ResourceT IO (Response Value)
 getValue res = do
     value <-
-#if MIN_VERSION_conduit(1,3,0)
+#if MIN_VERSION_http_conduit(2,3,0)
       C.runConduit $ responseBody res C..| sinkJSON
 #else
       responseBody res C.$$+- sinkJSON
@@ -134,8 +134,8 @@ checkResponse Response{..} =
     sci = HT.statusCode responseStatus
 
 getValueOrThrow :: FromJSON a
-#if MIN_VERSION_conduit(1,3,0)
-                => Response (C.ConduitT () ByteString (ResourceT IO) ())
+#if MIN_VERSION_http_conduit(2,3,0)
+                => Response (C.ConduitM () ByteString (ResourceT IO) ())
 #else
                 => Response (C.ResumableSource (ResourceT IO) ByteString)
 #endif

--- a/Web/Twitter/Conduit/Stream.hs
+++ b/Web/Twitter/Conduit/Stream.hs
@@ -32,6 +32,7 @@ import Web.Twitter.Conduit.Parameters.TH
 import Web.Twitter.Conduit.Request
 import Web.Twitter.Conduit.Response
 
+import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource (MonadResource)
 import Data.Aeson
@@ -44,6 +45,8 @@ import qualified Data.List as L
 import qualified Data.Text as T
 import qualified Network.HTTP.Conduit as HTTP
 
+#if MIN_VERSION_conduit(1,3,0)
+#else
 #if MIN_VERSION_conduit(1,0,16)
 ($=+) :: MonadIO m
       => CI.ResumableSource m a
@@ -55,22 +58,47 @@ rsrc $=+ cndt = do
     (src, finalizer) <- C.unwrapResumable rsrc
     return $ CI.ResumableSource (src C.$= cndt) finalizer
 #endif
+#endif
 
-stream :: (MonadResource m, FromJSON responseType)
+stream ::
+          ( MonadResource m
+          , FromJSON responseType
+#if MIN_VERSION_conduit(1,3,0)
+          , MonadThrow m
+#endif
+          )
        => TWInfo
        -> HTTP.Manager
        -> APIRequest apiName responseType
+#if MIN_VERSION_conduit(1,3,0)
+        -> m (C.ConduitT () responseType m ())
+#else
        -> m (C.ResumableSource m responseType)
+#endif
 stream = stream'
 
-stream' :: (MonadResource m, FromJSON value)
+stream' ::
+           ( MonadResource m
+           , FromJSON value
+#if MIN_VERSION_conduit(1,3,0)
+           , MonadThrow m
+#endif
+           )
         => TWInfo
         -> HTTP.Manager
         -> APIRequest apiName responseType
+#if MIN_VERSION_conduit(1,3,0)
+        -> m (C.ConduitT () value m ())
+#else
         -> m (C.ResumableSource m value)
+#endif
 stream' info mgr req = do
     rsrc <- getResponse info mgr =<< liftIO (makeRequest req)
+#if MIN_VERSION_conduit(1,3,0)
+    pure $ responseBody rsrc C..| CL.sequence sinkFromJSONIgnoreSpaces
+#else
     responseBody rsrc $=+ CL.sequence sinkFromJSONIgnoreSpaces
+#endif
   where
     sinkFromJSONIgnoreSpaces = CL.filter (not . S8.all isSpace) C.=$ sinkFromJSON
 

--- a/Web/Twitter/Conduit/Stream.hs
+++ b/Web/Twitter/Conduit/Stream.hs
@@ -70,8 +70,8 @@ stream ::
        => TWInfo
        -> HTTP.Manager
        -> APIRequest apiName responseType
-#if MIN_VERSION_conduit(1,3,0)
-        -> m (C.ConduitT () responseType m ())
+#if MIN_VERSION_http_conduit(2,3,0)
+        -> m (C.ConduitM () responseType m ())
 #else
        -> m (C.ResumableSource m responseType)
 #endif
@@ -87,14 +87,14 @@ stream' ::
         => TWInfo
         -> HTTP.Manager
         -> APIRequest apiName responseType
-#if MIN_VERSION_conduit(1,3,0)
-        -> m (C.ConduitT () value m ())
+#if MIN_VERSION_http_conduit(2,3,0)
+        -> m (C.ConduitM () value m ())
 #else
         -> m (C.ResumableSource m value)
 #endif
 stream' info mgr req = do
     rsrc <- getResponse info mgr =<< liftIO (makeRequest req)
-#if MIN_VERSION_conduit(1,3,0)
+#if MIN_VERSION_http_conduit(2,3,0)
     pure $ responseBody rsrc C..| CL.sequence sinkFromJSONIgnoreSpaces
 #else
     responseBody rsrc $=+ CL.sequence sinkFromJSONIgnoreSpaces

--- a/Web/Twitter/Conduit/Stream.hs
+++ b/Web/Twitter/Conduit/Stream.hs
@@ -95,7 +95,7 @@ stream' ::
 stream' info mgr req = do
     rsrc <- getResponse info mgr =<< liftIO (makeRequest req)
 #if MIN_VERSION_http_conduit(2,3,0)
-    pure $ responseBody rsrc C..| CL.sequence sinkFromJSONIgnoreSpaces
+    return $ responseBody rsrc C..| CL.sequence sinkFromJSONIgnoreSpaces
 #else
     responseBody rsrc $=+ CL.sequence sinkFromJSONIgnoreSpaces
 #endif

--- a/sample/userstream.hs
+++ b/sample/userstream.hs
@@ -39,7 +39,7 @@ main = do
     mgr <- newManager tlsManagerSettings
     runResourceT $ do
         src <- stream twInfo mgr userstream
-#if MIN_VERSION_conduit(1,3,0)
+#if MIN_VERSION_http_conduit(2,3,0)
         C.runConduit $ src C..| CL.mapM_ (liftIO . printTL)
 #else
         src C.$$+- CL.mapM_ (liftIO . printTL)
@@ -89,7 +89,7 @@ fetchIcon sn url = do
         mgr <- newManager tlsManagerSettings
         runResourceT $ do
             body <- http req mgr
-#if MIN_VERSION_conduit(1,3,0)
+#if MIN_VERSION_http_conduit(2,3,0)
             C.runConduit $ HTTP.responseBody body C..| CB.sinkFile fname
 #else
             HTTP.responseBody body $$+- CB.sinkFile fname

--- a/sample/userstream.hs
+++ b/sample/userstream.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 
@@ -38,7 +39,11 @@ main = do
     mgr <- newManager tlsManagerSettings
     runResourceT $ do
         src <- stream twInfo mgr userstream
+#if MIN_VERSION_conduit(1,3,0)
+        C.runConduit $ src C..| CL.mapM_ (liftIO . printTL)
+#else
         src C.$$+- CL.mapM_ (liftIO . printTL)
+#endif
 
 showStatus :: AsStatus s => s -> T.Text
 showStatus s = T.concat [ s ^. user . userScreenName
@@ -84,5 +89,9 @@ fetchIcon sn url = do
         mgr <- newManager tlsManagerSettings
         runResourceT $ do
             body <- http req mgr
+#if MIN_VERSION_conduit(1,3,0)
+            C.runConduit $ HTTP.responseBody body C..| CB.sinkFile fname
+#else
             HTTP.responseBody body $$+- CB.sinkFile fname
+#endif
     return fname

--- a/twitter-conduit.cabal
+++ b/twitter-conduit.cabal
@@ -66,7 +66,7 @@ library
     , conduit >= 1.1
     , conduit-extra >= 1.1
     , http-types
-    , http-conduit >= 2.0 && < 2.3
+    , http-conduit >= 2.0 && < 2.4
     , http-client >= 0.3.0
     , aeson >= 0.7.0.5
     , attoparsec >= 0.10


### PR DESCRIPTION
This PR adds support for both http-conduit-2.3 and conduit-1.3.

At work we are trying to use twitter-conduit with stackage's lts-11, which includes http-conduit-2.3 and conduit-1.3.  Once this gets merged it, it would be great if you could cut a release!

It seems like there are quite a few changes in conduit-1.3.  `ResumableSource` has been removed, so now some of the http-conduit functions just return a normal `Source` instead.  (Also, `Source` has been deprecated, and the conduit docs say to use the full `ConduitT` type.)  Now some of the functions in this package are returning a `ConduitT` instead of a `ResumableSource`.

Also, there was a problem with using `MonadBase IO`.  To be honest, I'm not sure what the problem was.  I think some type has lost a `MonadBase` instance, but I didn't really look into what has happened.  Instead, I just switched everything to using `MonadIO`.  I don't think there should be a problem with this, but if there is, let me know.

I think the Snoyman-family of libraries have been moving away from `MonadBase` and `MonadBaseControl` and instead settling on `MonadIO` and `UnliftIO`.  I thought this might be the reason for the `MonadBase IO` problem, but like I said, I didn't look into it.

I also modified the travis.yml file to test on ghc-8.4.3.

This PR would require a major version bump before being released to Hackage.