### PR TITLE
Drop support conduit < 1.3, http-conduit < 2.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@
 
   NOTE: See `Web.Twitter.Conduit.ParametersDeprecated` module if you would like to use classic value lenses.
 
+* Drop supports conduit < 1.3 and http-conduit < 2.3 [#69](https://github.com/himura/twitter-conduit/pull/69).
+
 ## 0.4.0
 
 * Follow direct message API changes [#65](https://github.com/himura/twitter-conduit/pull/65) [#62](https://github.com/himura/twitter-conduit/pull/62)

--- a/Web/Twitter/Conduit/Stream.hs
+++ b/Web/Twitter/Conduit/Stream.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
@@ -43,57 +42,29 @@ import qualified Data.List as L
 import qualified Data.Text as T
 import qualified Network.HTTP.Conduit as HTTP
 
-#if !MIN_VERSION_conduit(1,3,0)
-import qualified Data.Conduit.Internal as CI
-#endif
-
-#if !MIN_VERSION_conduit(1,3,0)
-($=+) :: MonadIO m
-      => CI.ResumableSource m a
-      -> CI.Conduit a m o
-      -> m (CI.ResumableSource m o)
-($=+) = (return .) . (C.$=+)
-#endif
-
 stream ::
           ( MonadResource m
           , FromJSON responseType
-#if MIN_VERSION_conduit(1,3,0)
           , MonadThrow m
-#endif
           )
        => TWInfo
        -> HTTP.Manager
        -> APIRequest apiName responseType
-#if MIN_VERSION_http_conduit(2,3,0)
         -> m (C.ConduitM () responseType m ())
-#else
-       -> m (C.ResumableSource m responseType)
-#endif
 stream = stream'
 
 stream' ::
            ( MonadResource m
            , FromJSON value
-#if MIN_VERSION_conduit(1,3,0)
            , MonadThrow m
-#endif
            )
         => TWInfo
         -> HTTP.Manager
         -> APIRequest apiName responseType
-#if MIN_VERSION_http_conduit(2,3,0)
         -> m (C.ConduitM () value m ())
-#else
-        -> m (C.ResumableSource m value)
-#endif
 stream' info mgr req = do
     rsrc <- getResponse info mgr =<< liftIO (makeRequest req)
-#if MIN_VERSION_http_conduit(2,3,0)
     return $ responseBody rsrc C..| CL.sequence sinkFromJSONIgnoreSpaces
-#else
-    responseBody rsrc $=+ CL.sequence sinkFromJSONIgnoreSpaces
-#endif
   where
     sinkFromJSONIgnoreSpaces = CL.filter (not . S8.all isSpace) C.=$ sinkFromJSON
 

--- a/Web/Twitter/Conduit/Stream.hs
+++ b/Web/Twitter/Conduit/Stream.hs
@@ -66,7 +66,7 @@ stream' info mgr req = do
     rsrc <- getResponse info mgr =<< liftIO (makeRequest req)
     return $ responseBody rsrc C..| CL.sequence sinkFromJSONIgnoreSpaces
   where
-    sinkFromJSONIgnoreSpaces = CL.filter (not . S8.all isSpace) C.=$ sinkFromJSON
+    sinkFromJSONIgnoreSpaces = CL.filter (not . S8.all isSpace) C..| sinkFromJSON
 
 userstream :: APIRequest Userstream StreamingAPI
 userstream = APIRequest "GET" "https://userstream.twitter.com/1.1/user.json" []

--- a/sample/oauth_callback.hs
+++ b/sample/oauth_callback.hs
@@ -9,14 +9,13 @@ module Main where
 
 import Web.Scotty
 import qualified Network.HTTP.Types as HT
-import Web.Twitter.Conduit hiding (lookup,url)
+import Web.Twitter.Conduit hiding (lookup)
 import qualified Web.Authenticate.OAuth as OA
 import qualified Data.Text.Lazy as LT
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.Map as M
 import Data.Maybe
-import Data.Monoid
 import Data.IORef
 import Control.Monad.IO.Class
 import System.Environment

--- a/sample/oauth_pin.hs
+++ b/sample/oauth_pin.hs
@@ -8,11 +8,10 @@
 
 module Main where
 
-import Web.Twitter.Conduit hiding (lookup,url)
+import Web.Twitter.Conduit hiding (lookup)
 import Web.Authenticate.OAuth as OA
 import qualified Data.ByteString.Char8 as S8
 import Data.Maybe
-import Data.Monoid
 import System.Environment
 import System.IO (hFlush, stdout)
 

--- a/sample/oslist.hs
+++ b/sample/oslist.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Web.Twitter.Conduit hiding (map)
+import Web.Twitter.Conduit
 import Common
 
-import qualified Data.Conduit as C
+import Data.Conduit
 import qualified Data.Conduit.List as CL
 import qualified Data.Map as M
 import System.Environment
@@ -16,8 +16,8 @@ main = do
     mgr <- newManager tlsManagerSettings
     let sn = ScreenNameParam screenName
 
-    folids <- sourceWithCursor twInfo mgr (followersIds sn) C.$$ CL.consume
-    friids <- sourceWithCursor twInfo mgr (friendsIds sn) C.$$ CL.consume
+    folids <- runConduit $ sourceWithCursor twInfo mgr (followersIds sn) .| CL.consume
+    friids <- runConduit $ sourceWithCursor twInfo mgr (friendsIds sn) .| CL.consume
 
     let folmap = M.fromList $ map (flip (,) True) folids
         os = filter (\uid -> M.notMember uid folmap) friids

--- a/sample/post.hs
+++ b/sample/post.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Web.Twitter.Conduit hiding (map)
+import Web.Twitter.Conduit
 import Common
 
-import Control.Applicative
-import Data.Monoid
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import System.Environment

--- a/sample/postWithMultipleMedia.hs
+++ b/sample/postWithMultipleMedia.hs
@@ -4,7 +4,6 @@
 module Main where
 
 import Web.Twitter.Conduit
-import qualified Web.Twitter.Conduit.Parameters as P
 import Web.Twitter.Types.Lens
 import Common
 

--- a/sample/searchSource.hs
+++ b/sample/searchSource.hs
@@ -22,4 +22,4 @@ main = do
     let metadata = res ^. searchResultSearchMetadata
     putStrLn $ "search completed in: " ++ metadata ^. searchMetadataCompletedIn . to show
     putStrLn $ "search result max id: " ++ metadata ^. searchMetadataMaxId . to show
-    res ^. searchResultStatuses $$ CL.isolate (read num) =$ CL.mapM_ print
+    runConduit $ res ^. searchResultStatuses .| CL.isolate (read num) .| CL.mapM_ print

--- a/sample/userstream.hs
+++ b/sample/userstream.hs
@@ -5,13 +5,11 @@ import Web.Twitter.Conduit
 import Web.Twitter.Types.Lens
 import Common
 
-import Control.Applicative
 import Control.Lens
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
 import Data.Conduit
-import qualified Data.Conduit as C
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Conduit.List as CL
 import qualified Data.Text as T
@@ -38,7 +36,7 @@ main = do
     mgr <- newManager tlsManagerSettings
     runResourceT $ do
         src <- stream twInfo mgr userstream
-        C.runConduit $ src C..| CL.mapM_ (liftIO . printTL)
+        runConduit $ src .| CL.mapM_ (liftIO . printTL)
 
 showStatus :: AsStatus s => s -> T.Text
 showStatus s = T.concat [ s ^. user . userScreenName
@@ -80,9 +78,9 @@ fetchIcon sn url = do
     let fname = ipath </> sn ++ "__" ++ takeFileName url
     exists <- doesFileExist fname
     unless exists $ do
-        req <- parseUrl url
+        req <- parseRequest url
         mgr <- newManager tlsManagerSettings
         runResourceT $ do
             body <- http req mgr
-            C.runConduit $ HTTP.responseBody body C..| CB.sinkFile fname
+            runConduit $ HTTP.responseBody body .| CB.sinkFile fname
     return fname

--- a/twitter-conduit.cabal
+++ b/twitter-conduit.cabal
@@ -56,14 +56,14 @@ library
     , attoparsec >= 0.10
     , authenticate-oauth >= 1.3
     , bytestring >= 0.10.2
-    , conduit >= 1.1
-    , conduit-extra >= 1.1
+    , conduit >= 1.3
+    , conduit-extra >= 1.3
     , containers
     , data-default >= 0.3
     , exceptions >= 0.5
     , ghc-prim
-    , http-client >= 0.3.0
-    , http-conduit >= 2.0 && < 2.4
+    , http-client >= 0.5.0
+    , http-conduit >= 2.3 && < 2.4
     , http-types
     , lens >= 4.4
     , lens-aeson >= 1


### PR DESCRIPTION
Drop older conduit and http-conduit version.

twitter-conduit 0.4.0 says that it supports `conduit >= 1.1`, but it already uses `.|` operator which is supported by conduit 1.2 or later.

https://github.com/himura/twitter-conduit/blob/0.4.0/Web/Twitter/Conduit/Base.hs