### PR TITLE
Do not re-export Web.Twitter.Conduit.Status

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,9 @@
   NOTE: See `Web.Twitter.Conduit.ParametersDeprecated` module if you would like to use classic value lenses.
 
 * Drop supports conduit < 1.3 and http-conduit < 2.3 [#69](https://github.com/himura/twitter-conduit/pull/69).
+* `Web.Twitter.Conduit.Status` is no longer re-exported by Web.Twitter.Conduit in order to avoid name conflictions (e.g. `update`, `lookup`) [71](https://github.com/himura/twitter-conduit/pull/71).
+* Add alias for functions in `Web.Twitter.Conduit.Status` with statuses- prefix [71](https://github.com/himura/twitter-conduit/pull/71).
+  (e.g. `Web.Twitter.Conduit.Api.statusesHomeTimeline` for `Web.Twitter.Conduit.Status.homeTimeline`)
 
 ## 0.4.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,8 +21,8 @@
   NOTE: See `Web.Twitter.Conduit.ParametersDeprecated` module if you would like to use classic value lenses.
 
 * Drop supports conduit < 1.3 and http-conduit < 2.3 [#69](https://github.com/himura/twitter-conduit/pull/69).
-* `Web.Twitter.Conduit.Status` is no longer re-exported by Web.Twitter.Conduit in order to avoid name conflictions (e.g. `update`, `lookup`) [71](https://github.com/himura/twitter-conduit/pull/71).
-* Add alias for functions in `Web.Twitter.Conduit.Status` with statuses- prefix [71](https://github.com/himura/twitter-conduit/pull/71).
+* `Web.Twitter.Conduit.Status` is no longer re-exported by Web.Twitter.Conduit in order to avoid name conflictions (e.g. `update`, `lookup`) [#71](https://github.com/himura/twitter-conduit/pull/71).
+* Add alias for functions in `Web.Twitter.Conduit.Status` with statuses- prefix [#71](https://github.com/himura/twitter-conduit/pull/71).
   (e.g. `Web.Twitter.Conduit.Api.statusesHomeTimeline` for `Web.Twitter.Conduit.Status.homeTimeline`)
 
 ## 0.4.0

--- a/Web/Twitter/Conduit.hs
+++ b/Web/Twitter/Conduit.hs
@@ -20,7 +20,6 @@ module Web.Twitter.Conduit
        , module Web.Twitter.Conduit.Cursor
        , module Web.Twitter.Conduit.Request
        , module Web.Twitter.Conduit.Response
-       , module Web.Twitter.Conduit.Status
        , module Web.Twitter.Conduit.Stream
        , module Web.Twitter.Conduit.Types
 
@@ -57,7 +56,6 @@ import Web.Twitter.Conduit.Cursor
 import Web.Twitter.Conduit.Parameters
 import Web.Twitter.Conduit.Request
 import Web.Twitter.Conduit.Response
-import Web.Twitter.Conduit.Status
 import Web.Twitter.Conduit.Stream
 import Web.Twitter.Conduit.Types
 

--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -190,6 +190,7 @@ type SearchTweets = '[
 search :: T.Text -- ^ search string
        -> APIRequest SearchTweets (SearchResult [Status])
 search = searchTweets
+{-# DEPRECATED search "Please use Web.Twitter.Conduit.searchTweets" #-}
 
 -- | Returns query data which asks recent direct messages sent to the authenticating user.
 --

--- a/Web/Twitter/Conduit/Api.hs
+++ b/Web/Twitter/Conduit/Api.hs
@@ -6,8 +6,21 @@
 
 module Web.Twitter.Conduit.Api
        (
+       -- * Status
+         statusesMentionsTimeline
+       , statusesUserTimeline
+       , statusesHomeTimeline
+       , statusesRetweetsOfMe
+       , statusesRetweetsId
+       , statusesShowId
+       , statusesDestroyId
+       , statusesUpdate
+       , statusesRetweetId
+       , statusesUpdateWithMedia
+       , statusesLookup
+
        -- * Search
-         SearchTweets
+       , SearchTweets
        , searchTweets
        , search
 
@@ -143,12 +156,13 @@ module Web.Twitter.Conduit.Api
        , mediaUpload
        ) where
 
-import Web.Twitter.Types
-import Web.Twitter.Conduit.Parameters
 import Web.Twitter.Conduit.Base
+import Web.Twitter.Conduit.Cursor
+import Web.Twitter.Conduit.Parameters
 import Web.Twitter.Conduit.Request
 import Web.Twitter.Conduit.Request.Internal
-import Web.Twitter.Conduit.Cursor
+import qualified Web.Twitter.Conduit.Status as Status
+import Web.Twitter.Types
 
 import Network.HTTP.Client.MultipartFormData
 import qualified Data.Text as T
@@ -937,3 +951,26 @@ mediaUpload mediaData =
     mediaBody (MediaFromFile fp) = partFileSource "media" fp
     mediaBody (MediaRequestBody filename filebody) = partFileRequestBody "media" filename filebody
 type MediaUpload = EmptyParams
+
+statusesMentionsTimeline :: APIRequest Status.StatusesMentionsTimeline [Status]
+statusesMentionsTimeline = Status.mentionsTimeline
+statusesUserTimeline :: UserParam -> APIRequest Status.StatusesUserTimeline [Status]
+statusesUserTimeline = Status.userTimeline
+statusesHomeTimeline :: APIRequest Status.StatusesHomeTimeline [Status]
+statusesHomeTimeline = Status.homeTimeline
+statusesRetweetsOfMe :: APIRequest Status.StatusesRetweetsOfMe [Status]
+statusesRetweetsOfMe = Status.retweetsOfMe
+statusesRetweetsId :: StatusId -> APIRequest Status.StatusesRetweetsId [RetweetedStatus]
+statusesRetweetsId = Status.retweetsId
+statusesShowId :: StatusId -> APIRequest Status.StatusesShowId Status
+statusesShowId = Status.showId
+statusesDestroyId :: StatusId -> APIRequest Status.StatusesDestroyId Status
+statusesDestroyId = Status.destroyId
+statusesUpdate :: T.Text -> APIRequest Status.StatusesUpdate Status
+statusesUpdate = Status.update
+statusesRetweetId :: StatusId -> APIRequest Status.StatusesRetweetId RetweetedStatus
+statusesRetweetId = Status.retweetId
+statusesUpdateWithMedia :: T.Text -> MediaData -> APIRequest Status.StatusesUpdateWithMedia Status
+statusesUpdateWithMedia = Status.updateWithMedia
+statusesLookup :: [StatusId] -> APIRequest Status.StatusesLookup [Status]
+statusesLookup = Status.lookup

--- a/sample/fav.hs
+++ b/sample/fav.hs
@@ -15,7 +15,7 @@ main = do
     mgr <- newManager tlsManagerSettings
     let sId = read statusIdStr
 
-    targetStatus <- call twInfo mgr $ showId sId
+    targetStatus <- call twInfo mgr $ statusesShowId sId
     putStrLn $ "Favorite Tweet: " ++ targetStatus ^. to show
     res <- call twInfo mgr $ favoritesCreate sId
     print res

--- a/sample/oauth_callback.hs
+++ b/sample/oauth_callback.hs
@@ -9,7 +9,7 @@ module Main where
 
 import Web.Scotty
 import qualified Network.HTTP.Types as HT
-import Web.Twitter.Conduit hiding (lookup)
+import Web.Twitter.Conduit
 import qualified Web.Authenticate.OAuth as OA
 import qualified Data.Text.Lazy as LT
 import qualified Data.ByteString as S

--- a/sample/post.hs
+++ b/sample/post.hs
@@ -14,5 +14,5 @@ main = do
     T.putStrLn $ "Post message: " <> status
     twInfo <- getTWInfoFromEnv
     mgr <- newManager tlsManagerSettings
-    res <- call twInfo mgr $ update status
+    res <- call twInfo mgr $ statusesUpdate status
     print res

--- a/sample/postWithMedia.hs
+++ b/sample/postWithMedia.hs
@@ -13,5 +13,5 @@ main = do
     putStrLn $ "Post message: " ++ status
     twInfo <- getTWInfoFromEnv
     mgr <- newManager tlsManagerSettings
-    res <- call twInfo mgr $ updateWithMedia (T.pack status) (MediaFromFile filepath)
+    res <- call twInfo mgr $ statusesUpdateWithMedia (T.pack status) (MediaFromFile filepath)
     print res

--- a/sample/postWithMultipleMedia.hs
+++ b/sample/postWithMultipleMedia.hs
@@ -28,5 +28,5 @@ main = do
         putStrLn $ "Upload completed: media_id: " ++ ret ^. uploadedMediaId . to show ++ ", filepath: " ++ filepath
         return ret
     putStrLn $ "Post message: " ++ status
-    res <- call twInfo mgr $ update (T.pack status) & #media_ids ?~ (uploadedMediaList ^.. traversed .  uploadedMediaId)
+    res <- call twInfo mgr $ statusesUpdate (T.pack status) & #media_ids ?~ (uploadedMediaList ^.. traversed .  uploadedMediaId)
     print res

--- a/sample/simple.hs
+++ b/sample/simple.hs
@@ -49,7 +49,7 @@ main = do
     mgr <- newManager tlsManagerSettings
     twInfo <- getTWInfo mgr
     putStrLn $ "# your home timeline (up to 800 tweets):"
-    runConduit $ sourceWithMaxId twInfo mgr (homeTimeline & #count ?~ 200)
+    runConduit $ sourceWithMaxId twInfo mgr (statusesHomeTimeline & #count ?~ 200)
         .| CL.isolate 800
         .| CL.mapM_
             (\status -> do


### PR DESCRIPTION
The current implementation of `Web.Twitter.Conduit.Status` exports APIs that name conflict with Prelude functions (e.g. `lookup`). It may force users to write inconvenience qualified import or name hiding.

In order to avoid this, this PR does:

- Removes the re-export of `W.T.Conduit.Status` in `W.T.Conduit`.
- Add status API aliases to `W.T.Conduit` with statuses- prefix.