### PR TITLE
Extend to add "tweet_mode" parameter

### DIFF
--- a/Web/Twitter/Conduit/Status.hs
+++ b/Web/Twitter/Conduit/Status.hs
@@ -69,6 +69,7 @@ type StatusesMentionsTimeline = '[
     , "trim_user" ':= Bool
     , "contributor_details" ':= Bool
     , "include_entities" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns query data asks a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
@@ -93,6 +94,7 @@ type StatusesUserTimeline = '[
     , "exclude_replies" ':= Bool
     , "contributor_details" ':= Bool
     , "include_rts" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns query data asks a collection of the most recentTweets and retweets posted by the authenticating user and the users they follow.
@@ -117,6 +119,7 @@ type StatusesHomeTimeline = '[
     , "exclude_replies" ':= Bool
     , "contributor_details" ':= Bool
     , "include_entities" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns query data asks the most recent tweets authored by the authenticating user that have been retweeted by others.
@@ -140,6 +143,7 @@ type StatusesRetweetsOfMe = '[
     , "trim_user" ':= Bool
     , "include_entities" ':= Bool
     , "include_user_entities" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- * Tweets
@@ -184,6 +188,7 @@ type StatusesShowId = '[
     , "include_my_retweet" ':= Bool
     , "include_entities" ':= Bool
     , "include_ext_alt_text" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns post data which destroys the status specified by the require ID parameter.
@@ -201,6 +206,7 @@ destroyId status_id = APIRequest "POST" uri def
   where uri = endpoint ++ "statuses/destroy/" ++ show status_id ++ ".json"
 type StatusesDestroyId = '[
       "trim_user" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns post data which updates the authenticating user's current status.
@@ -226,6 +232,7 @@ type StatusesUpdate = '[
     , "display_coordinates" ':= Bool
     , "trim_user" ':= Bool
     , "media_ids" ':= [Integer]
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns post data which retweets a tweet, specified by ID.
@@ -270,6 +277,7 @@ type StatusesUpdateWithMedia = '[
     -- , "lat_long"
     -- , "place_id"
     , "display_coordinates" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]
 
 -- | Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by comma-separated values passed to the id parameter.
@@ -292,4 +300,5 @@ type StatusesLookup = '[
       "include_entities" ':= Bool
     , "trim_user" ':= Bool
     , "map" ':= Bool
+    , "tweet_mode" ':= T.Text
     ]


### PR DESCRIPTION
This allows client to set `tweet_mode=extended` on related APIs, which I believe are all those that returns `Status`, or structures that contain `Status`.

For what this parameter does, see: https://developer.twitter.com/en/docs/tweets/tweet-updates.html.

This PR can be considered a partial fix to #60 -  by partial I meant by setting `tweet_mode=extended`, compatibility mode streaming api will have an extra `extended_tweet` field as described in the official doc, but I have no access to that api nor a way of verifying it, so I'll just leave it be for now.
