### PR TITLE
Support giving a count parameter to paginated user requests.

### DIFF
--- a/Web/Twitter/Conduit/Parameters.hs
+++ b/Web/Twitter/Conduit/Parameters.hs
@@ -10,6 +10,7 @@ module Web.Twitter.Conduit.Parameters
        , mkListParam
        ) where
 
+import Data.Default (Default (..))
 import Data.Maybe (catMaybes)
 import qualified Data.Text as T
 import Network.HTTP.Client (RequestBody)
@@ -20,9 +21,9 @@ import Web.Twitter.Types
 -- >>> import Web.Twitter.Conduit.Request.Internal
 
 data UserParam = UserParam
-  { userId :: Maybe UserId
-  , userScreenName :: Maybe String
-  , userCount :: Maybe Integer
+  { upId :: Maybe UserId
+  , upScreenName :: Maybe String
+  , upCount :: Maybe Integer
   } deriving (Show, Eq)
 data UserListParam = UserIdListParam [UserId] | ScreenNameListParam [String]
                    deriving (Show, Eq)
@@ -30,6 +31,13 @@ data ListParam = ListIdParam Integer | ListNameParam String
                deriving (Show, Eq)
 data MediaData = MediaFromFile FilePath
                | MediaRequestBody FilePath RequestBody
+
+instance Default UserParam where
+  def = UserParam
+    { upId = Nothing
+    , upScreenName = Nothing
+    , upCount = Nothing
+    }
 
 -- | converts 'UserParam' to 'HT.SimpleQuery'.
 --

--- a/Web/Twitter/Conduit/Parameters.hs
+++ b/Web/Twitter/Conduit/Parameters.hs
@@ -10,6 +10,7 @@ module Web.Twitter.Conduit.Parameters
        , mkListParam
        ) where
 
+import Data.Maybe (catMaybes)
 import qualified Data.Text as T
 import Network.HTTP.Client (RequestBody)
 import Web.Twitter.Conduit.Request.Internal (APIQuery, PV(..))
@@ -18,8 +19,11 @@ import Web.Twitter.Types
 -- $setup
 -- >>> import Web.Twitter.Conduit.Request.Internal
 
-data UserParam = UserIdParam UserId | ScreenNameParam String
-               deriving (Show, Eq)
+data UserParam = UserParam
+  { userId :: Maybe UserId
+  , userScreenName :: Maybe String
+  , userCount :: Maybe Integer
+  } deriving (Show, Eq)
 data UserListParam = UserIdListParam [UserId] | ScreenNameListParam [String]
                    deriving (Show, Eq)
 data ListParam = ListIdParam Integer | ListNameParam String
@@ -34,8 +38,11 @@ data MediaData = MediaFromFile FilePath
 -- >>> makeSimpleQuery . mkUserParam $ ScreenNameParam "thimura"
 -- [("screen_name","thimura")]
 mkUserParam :: UserParam -> APIQuery
-mkUserParam (UserIdParam uid) =  [("user_id", PVInteger uid)]
-mkUserParam (ScreenNameParam sn) = [("screen_name", PVString . T.pack $ sn)]
+mkUserParam (UserParam uid usn uc) = catMaybes
+  [ (,) "user_id" . PVInteger <$> uid
+  , (,) "screen_name" . PVString . T.pack <$> usn
+  , (,) "count" . PVInteger <$> uc
+  ]
 
 -- | converts 'UserListParam' to 'HT.SimpleQuery'.
 --

--- a/tests/ApiSpec.hs
+++ b/tests/ApiSpec.hs
@@ -38,11 +38,11 @@ integrated :: Spec
 integrated = do
     describe "friendsIds" $ do
         it "returns a cursored collection of users IDs" $ do
-            res <- call twInfo mgr $ friendsIds (Param.ScreenNameParam "thimura")
+            res <- call twInfo mgr $ friendsIds def { Param.upScreenName = Just "thimura" }
             res ^. contents . to length `shouldSatisfy` (> 0)
 
         it "iterate with sourceWithCursor" $ do
-            let src = sourceWithCursor twInfo mgr $ friendsIds (Param.ScreenNameParam "thimura")
+            let src = sourceWithCursor twInfo mgr $ friendsIds def { Param.upScreenName = Just "thimura" }
             friends <- src $$ CL.consume
             length friends `shouldSatisfy` (>= 0)
 

--- a/tests/StatusSpec.hs
+++ b/tests/StatusSpec.hs
@@ -52,17 +52,17 @@ integrated = do
 
     describe "userTimeline" $ do
         it "returns the 20 most recent tweets posted by the user indicated by ScreenNameParam" $ do
-            res <- call twInfo mgr $ userTimeline (def { Param.upScreenName = "thimura" })
+            res <- call twInfo mgr $ userTimeline (def { Param.upScreenName = Just "thimura" })
             length res `shouldSatisfy` (== 20)
             res `shouldSatisfy` (allOf folded (^. statusUser . userScreenName . to (== "thimura")))
         it "returns the recent tweets which include RTs when specified include_rts option" $ do
             res <- call twInfo mgr
-                   $ userTimeline (def { Param.upScreenName = "thimura" })
+                   $ userTimeline (def { Param.upScreenName = Just "thimura" })
                    & #count ?~ 100 & #include_rts ?~ True
             res `shouldSatisfy` (anyOf (folded . statusRetweetedStatus . _Just . statusUser . userScreenName) (/= "thimura"))
         it "iterate with sourceWithMaxId" $ do
             let src = sourceWithMaxId twInfo mgr $
-                      userTimeline (def { Param.upScreenName = "thimura" }) & #count ?~ 200
+                      userTimeline (def { Param.upScreenName = Just "thimura" }) & #count ?~ 200
             tl <- src $$ CL.isolate 600 =$ CL.consume
             length tl `shouldSatisfy` (== 600)
 

--- a/tests/StatusSpec.hs
+++ b/tests/StatusSpec.hs
@@ -51,17 +51,17 @@ integrated = do
 
     describe "userTimeline" $ do
         it "returns the 20 most recent tweets posted by the user indicated by ScreenNameParam" $ do
-            res <- call twInfo mgr $ userTimeline (def {upScreenName = "thimura"})
+            res <- call twInfo mgr $ userTimeline (def { Param.upScreenName = "thimura" })
             length res `shouldSatisfy` (== 20)
             res `shouldSatisfy` (allOf folded (^. statusUser . userScreenName . to (== "thimura")))
         it "returns the recent tweets which include RTs when specified include_rts option" $ do
             res <- call twInfo mgr
-                   $ userTimeline (def {upScreenName = "thimura"})
+                   $ userTimeline (def { Param.upScreenName = "thimura" })
                    & #count ?~ 100 & #include_rts ?~ True
             res `shouldSatisfy` (anyOf (folded . statusRetweetedStatus . _Just . statusUser . userScreenName) (/= "thimura"))
         it "iterate with sourceWithMaxId" $ do
             let src = sourceWithMaxId twInfo mgr $
-                      userTimeline (def {upScreenName = "thimura"}) & #count ?~ 200
+                      userTimeline (def { Param.upScreenName = "thimura" }) & #count ?~ 200
             tl <- src $$ CL.isolate 600 =$ CL.consume
             length tl `shouldSatisfy` (== 600)
 

--- a/tests/StatusSpec.hs
+++ b/tests/StatusSpec.hs
@@ -7,6 +7,7 @@ module StatusSpec where
 import Control.Lens
 import Data.Conduit
 import qualified Data.Conduit.List as CL
+import Data.Default (def)
 import Data.Time
 import Network.HTTP.Conduit
 import System.IO.Unsafe

--- a/tests/StatusSpec.hs
+++ b/tests/StatusSpec.hs
@@ -51,17 +51,17 @@ integrated = do
 
     describe "userTimeline" $ do
         it "returns the 20 most recent tweets posted by the user indicated by ScreenNameParam" $ do
-            res <- call twInfo mgr $ userTimeline (Param.ScreenNameParam "thimura")
+            res <- call twInfo mgr $ userTimeline (def {upScreenName = "thimura"})
             length res `shouldSatisfy` (== 20)
             res `shouldSatisfy` (allOf folded (^. statusUser . userScreenName . to (== "thimura")))
         it "returns the recent tweets which include RTs when specified include_rts option" $ do
             res <- call twInfo mgr
-                   $ userTimeline (Param.ScreenNameParam "thimura")
+                   $ userTimeline (def {upScreenName = "thimura"})
                    & #count ?~ 100 & #include_rts ?~ True
             res `shouldSatisfy` (anyOf (folded . statusRetweetedStatus . _Just . statusUser . userScreenName) (/= "thimura"))
         it "iterate with sourceWithMaxId" $ do
             let src = sourceWithMaxId twInfo mgr $
-                      userTimeline (Param.ScreenNameParam "thimura") & #count ?~ 200
+                      userTimeline (def {upScreenName = "thimura"}) & #count ?~ 200
             tl <- src $$ CL.isolate 600 =$ CL.consume
             length tl `shouldSatisfy` (== 600)
 


### PR DESCRIPTION
Twitter allows supplying a 'count' parameter of up to 200 in paginated requests for users. Since this is 10 times the default amount of 20, this can be a great help for use cases that need to pull down many users, e.g., a spider. (https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list)

I've changed `UserParam` into a record type with all fields optional, and used `catMaybes` in `mkUserParam` to build the parameters object from only what is specified. In this way, a user can specify either a `UserId` or a user screen name, and, optionally, a count if they wish to override the Twitter-side default of 20.

This is a draft PR until I give it some live testing, as my application isn't yet ready to go live.